### PR TITLE
Moved to another namespace for easier usage

### DIFF
--- a/HappyTravel.Suppliers.sln
+++ b/HappyTravel.Suppliers.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HappyTravel.Suppliers", "HappyTravel.Suppliers\HappyTravel.Suppliers.csproj", "{D84A22FD-9F28-4302-8396-C210A42E1118}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HappyTravel.SuppliersCatalog", "HappyTravel.SuppliersCatalog\HappyTravel.SuppliersCatalog.csproj", "{D84A22FD-9F28-4302-8396-C210A42E1118}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/HappyTravel.SuppliersCatalog/HappyTravel.SuppliersCatalog.csproj
+++ b/HappyTravel.SuppliersCatalog/HappyTravel.SuppliersCatalog.csproj
@@ -8,12 +8,12 @@
         <Company>HappyTravel</Company>
         <Authors>Vadim Mingazhev</Authors>
         <Description>HappyTravel suppliers list</Description>
-        <PackageReleaseNotes>Init</PackageReleaseNotes>
+        <PackageReleaseNotes>Changed project namespaces for easier usage</PackageReleaseNotes>
         <PackageProjectUrl>https://github.com/happy-travel/suppliers</PackageProjectUrl>
         <RepositoryURL>https://github.com/happy-travel/suppliers</RepositoryURL>
-        <Version>0.8.0</Version>
+        <Version>0.8.1</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>0.8.0</PackageVersion>
+        <PackageVersion>0.8.1</PackageVersion>
     </PropertyGroup>
 
 </Project>

--- a/HappyTravel.SuppliersCatalog/Suppliers.cs
+++ b/HappyTravel.SuppliersCatalog/Suppliers.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace HappyTravel.Suppliers.Enums
+namespace HappyTravel.SuppliersCatalog
 {
     public enum Suppliers
     {


### PR DESCRIPTION
Changed a root namespace and assembly name to allow use "Suppliers" as `Suppliers`, not as `Suppliers.Enums.Suppliers`